### PR TITLE
fix: properly handle an empty variantImages array

### DIFF
--- a/plugin/src/domain/shared/mappers/DefaultProductMapper.spec.ts
+++ b/plugin/src/domain/shared/mappers/DefaultProductMapper.spec.ts
@@ -30,6 +30,15 @@ describe('map CT product to Klaviyo product', () => {
         expect(klaviyoEvent).toMatchSnapshot();
     });
 
+    it('should map commercetools product variants with an empty images array to a klaviyo variants', () => {
+        const variant = { ...structuredClone(ctGet1Product.results[0].masterData.current.masterVariant), images: [] };
+        const klaviyoEvent = productMapper.mapCtProductVariantToKlaviyoVariant(
+            ctGet1Product.results[0] as unknown as Product,
+            variant as unknown as ProductVariant,
+        );
+        expect(klaviyoEvent).toMatchSnapshot();
+    });
+
     it('should map secondary locales to appropiate custom_metadata properties', () => {
         const customProduct = {
             ...ctGet1Product.results[0],

--- a/plugin/src/domain/shared/mappers/DefaultProductMapper.ts
+++ b/plugin/src/domain/shared/mappers/DefaultProductMapper.ts
@@ -129,7 +129,7 @@ export class DefaultProductMapper implements ProductMapper {
                     description: productDescription ? getLocalizedStringAsText(productDescription) : '',
                     sku: !update ? productVariant.sku : undefined,
                     url: productUrl,
-                    image_full_url: variantImages ? variantImages[0].url : undefined,
+                    image_full_url: variantImages?.[0]?.url,
                     inventory_quantity: variantInventoryQuantity ?? 0,
                     inventory_policy: 1,
                     price: variantPrice ? this.currencyService.convert(variantPrice.amount, variantPrice.currency) : 0,

--- a/plugin/src/domain/shared/mappers/__snapshots__/DefaultProductMapper.spec.ts.snap
+++ b/plugin/src/domain/shared/mappers/__snapshots__/DefaultProductMapper.spec.ts.snap
@@ -416,6 +416,45 @@ exports[`map CT product to Klaviyo product should map commercetools product vari
 }
 `;
 
+exports[`map CT product to Klaviyo product should map commercetools product variants with an empty images array to a klaviyo variants 1`] = `
+{
+  "data": {
+    "attributes": {
+      "catalog_type": "$default",
+      "custom_metadata": {
+        "currency_json": "{"currency_AD":"EUR","currency_AT":"EUR","currency_AX":"EUR","currency_BE":"EUR","currency_BL":"EUR","currency_CP":"EUR","currency_CY":"EUR","currency_DE":"EUR","currency_EA":"EUR","currency_EE":"EUR","currency_ES":"EUR","currency_EU":"EUR","currency_FI":"EUR","currency_FR":"EUR","currency_FX":"EUR","currency_GF":"EUR","currency_GP":"EUR","currency_GR":"EUR","currency_IC":"EUR","currency_IE":"EUR","currency_IT":"EUR","currency_LT":"EUR","currency_LU":"EUR","currency_LV":"EUR","currency_MC":"EUR","currency_ME":"EUR","currency_MF":"EUR","currency_MQ":"EUR","currency_MT":"EUR","currency_NL":"EUR","currency_PM":"EUR","currency_PT":"EUR","currency_RE":"EUR","currency_SI":"EUR","currency_SK":"EUR","currency_SM":"EUR","currency_TF":"EUR","currency_VA":"EUR","currency_XK":"EUR","currency_YT":"EUR","currency_ZW":"EUR","currency_US":"USD"}",
+        "price_json": "{"price_EUR":118.75,"price_AD":118.75,"price_AT":118.75,"price_AX":118.75,"price_BE":118.75,"price_BL":118.75,"price_CP":118.75,"price_CY":118.75,"price_DE":118.75,"price_EA":118.75,"price_EE":118.75,"price_ES":118.75,"price_EU":118.75,"price_FI":118.75,"price_FR":118.75,"price_FX":118.75,"price_GF":118.75,"price_GP":118.75,"price_GR":118.75,"price_IC":118.75,"price_IE":118.75,"price_IT":118.75,"price_LT":118.75,"price_LU":118.75,"price_LV":118.75,"price_MC":118.75,"price_ME":118.75,"price_MF":118.75,"price_MQ":118.75,"price_MT":118.75,"price_NL":118.75,"price_PM":118.75,"price_PT":118.75,"price_RE":118.75,"price_SI":118.75,"price_SK":118.75,"price_SM":118.75,"price_TF":118.75,"price_VA":118.75,"price_XK":118.75,"price_YT":118.75,"price_ZW":118.75,"price_USD":118.75,"price_US":118.75}",
+        "slug_json": "{"slug_en":"gum-bag-medium-BS1900-black","slug_de":"gum-tasche-medium-BS1900-schwarz"}",
+        "title_json": "{"title_en":"Bag medium GUM black","title_de":"Tasche medium GUM schwarz"}",
+      },
+      "description": "",
+      "external_id": "A0E2000000027DV",
+      "image_full_url": undefined,
+      "integration_type": "$custom",
+      "inventory_policy": 1,
+      "inventory_quantity": 0,
+      "price": 118.75,
+      "published": true,
+      "sku": "A0E2000000027DV",
+      "title": "Bag medium GUM black",
+      "url": "https://example-store.com/products/gum-bag-medium-BS1900-black",
+    },
+    "id": undefined,
+    "relationships": {
+      "items": {
+        "data": [
+          {
+            "id": "$custom:::$default:::cb09966e-cb7a-4c3a-8eb5-e07f1a53ab8b",
+            "type": "catalog-item",
+          },
+        ],
+      },
+    },
+    "type": "catalog-variant",
+  },
+}
+`;
+
 exports[`map CT product to Klaviyo product should map secondary locales to appropiate custom_metadata properties 1`] = `
 {
   "data": {


### PR DESCRIPTION
When attempting to map a Product Variant where the images property is an empty array, the mapper throws an error:

```
TypeError: Cannot read properties of undefined (reading 'url')
    at DefaultProductMapper.mapCtProductVariantToKlaviyoVariant (/git/commercetools-klaviyo/plugin/src/domain/shared/mappers/DefaultProductMapper.ts:132:70)
    at /git/commercetools-klaviyo/plugin/src/domain/shared/mappers/DefaultProductMapper.ts:241:44
    at Array.map (<anonymous>)
    at DefaultProductMapper.mapCtProductVariantsToKlaviyoVariantsJob (/git/commercetools-klaviyo/plugin/src/domain/shared/mappers/DefaultProductMapper.ts:239:47)
    at ProductsSync.generateProductVariantsJobRequestForKlaviyo (/git/commercetools-klaviyo/plugin/src/domain/bulkSync/ProductsSync.ts:254:42)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /git/commercetools-klaviyo/plugin/src/domain/bulkSync/ProductsSync.ts:55:41
    at async Promise.all (index 2)
    at async ProductsSync.syncAllProducts (/git/commercetools-klaviyo/plugin/src/domain/bulkSync/ProductsSync.ts:50:25)
    at async /git/commercetools-klaviyo/plugin/src/infrastructure/driving/adapter/bulkSync/jobs/productsSync.ts:38:3
```

I believe this is because at some point we added an image to the variant in CommerceTools, then later on we removed that image, so the array continued to exist but no longer had any elements. 

This PR resolves that by correctly handling an empty array.